### PR TITLE
Serve index.html when no API call is mathing

### DIFF
--- a/main.go
+++ b/main.go
@@ -46,6 +46,7 @@ func router(appCtx *context) *mux.Router {
 	r.Handle("/users/{id}", appHandler{appCtx, Get}).Methods("GET")
 	r.Handle("/users/{id}", appHandler{appCtx, Update}).Methods("PUT")
 	r.Handle("/users/{id}", appHandler{appCtx, Delete}).Methods("DELETE")
+	r.NotFoundHandler = http.HandlerFunc(NotFound)
 	return r
 }
 
@@ -188,4 +189,10 @@ func check(err error) {
 		debug.PrintStack()
 		log.Fatal()
 	}
+}
+
+func NotFound(w http.ResponseWriter, r *http.Request) {
+	url := "/"
+	http.Redirect(w, r, url, http.StatusFound)
+	return
 }

--- a/main.go
+++ b/main.go
@@ -192,6 +192,5 @@ func check(err error) {
 }
 
 func NotFound(w http.ResponseWriter, r *http.Request) {
-	url := "/"
-	http.Redirect(w, r, url, http.StatusFound)
+	http.ServeFile(w, r, "static/index.html")
 }

--- a/main.go
+++ b/main.go
@@ -194,5 +194,4 @@ func check(err error) {
 func NotFound(w http.ResponseWriter, r *http.Request) {
 	url := "/"
 	http.Redirect(w, r, url, http.StatusFound)
-	return
 }


### PR DESCRIPTION
This pull request makes possible to use ui.router and ngRoute, as all URLs except RESTFUL API calls are serving index.html.
